### PR TITLE
Fix reorder button appearing on all device views

### DIFF
--- a/netbox_reorder_rack/__init__.py
+++ b/netbox_reorder_rack/__init__.py
@@ -5,7 +5,7 @@ class NetboxReorderRackConfig(PluginConfig):
     name = "netbox_reorder_rack"
     verbose_name = "NetBox Reorder Rack"
     description = "NetBox plugin to reorder rack layouts."
-    version = "1.1.3"
+    version = "1.1.4"
     base_url = "reorder"
 
 

--- a/netbox_reorder_rack/template_content.py
+++ b/netbox_reorder_rack/template_content.py
@@ -2,7 +2,7 @@ from netbox.plugins import PluginTemplateExtension
 
 
 class ReorderButton(PluginTemplateExtension):
-    model = "dcim.rack"
+    models = ["dcim.rack"]
 
     def buttons(self):
         return self.render("netbox_reorder_rack/inc/rack_button.html")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="netbox_reorder_rack",
-    version="1.1.3",
+    version="1.1.4",
     author="Alex Gittings",
     author_email="agitting96@gmail.com",
     description="NetBox plugin to reorder rack layouts.",


### PR DESCRIPTION
- Change `model` to `models` list in ReorderButton template extension
- Ensures reorder button only appears on rack views as intended
- Resolves issue where button was showing on all DCIM object views
- Bump version to 1.1.4

Fixes #36